### PR TITLE
use rapidfuzz instead of fuzzywuzzy

### DIFF
--- a/apiserver/apiserver/api/views.py
+++ b/apiserver/apiserver/api/views.py
@@ -13,7 +13,7 @@ from rest_framework.permissions import BasePermission, IsAuthenticated, SAFE_MET
 from rest_framework.response import Response
 from rest_auth.views import PasswordChangeView
 from rest_auth.registration.views import RegisterView
-from fuzzywuzzy import fuzz, process
+from rapidfuzz import fuzz, process
 from collections import OrderedDict
 import datetime
 

--- a/apiserver/requirements.txt
+++ b/apiserver/requirements.txt
@@ -13,7 +13,6 @@ django-rest-auth==0.9.5
 django-simple-history==2.8.0
 djangorestframework==3.11.0
 docutils==0.16
-fuzzywuzzy==0.17.0
 gunicorn==20.0.4
 idna==2.8
 imagesize==1.2.0
@@ -27,10 +26,10 @@ Pygments==2.5.2
 pyparsing==2.4.6
 PyPDF2==1.26.0
 python-dateutil==2.8.1
-python-Levenshtein==0.12.0
 python-memcached==1.59
 python3-openid==3.1.0
 pytz==2019.3
+rapidfuzz==0.7.6
 reportlab==3.5.34
 requests==2.22.0
 requests-oauthlib==1.3.0


### PR DESCRIPTION
FuzzyWuzzy is GPLv2 licensed which would force you to licence the whole project under GPLv2.
For this reason this Pullrequest replaces FuzzyWuzzy with  [rapidfuzz](https://github.com/maxbachmann/rapidfuzz) which is implementing the same algorithm but is based on a version of fuzzywuzzy that was MIT Licensed.
Rapidfuzz is:
- Mit licensed so it can be used with the license used by this project
- Is faster than FuzzyWuzzy