### PR TITLE
Fix tests

### DIFF
--- a/apiserver/apiserver/api/tests.py
+++ b/apiserver/apiserver/api/tests.py
@@ -9,12 +9,6 @@ from rest_framework.exceptions import ValidationError
 
 from apiserver.api import utils, utils_paypal, models
 
-testing_member, _ = models.Member.objects.get_or_create(
-    first_name='unittest',
-    preferred_name='unittest',
-    last_name='tester',
-)
-
 class TestMonthsSpanned(TestCase):
     def test_num_months_spanned_one_month(self):
         date2 = datetime.date(2020, 1, 10)
@@ -201,10 +195,27 @@ class TestCalcStatus(TestCase):
 
 
 class TestTallyMembership(TestCase):
+    def get_user(self):
+        testing_user, _ = models.User.objects.get_or_create(
+            first_name='unittest',
+            username='unittest',
+            last_name='tester',
+            email='unittest@unittest.com'
+        )
+        return testing_user
+
     def get_member_clear_transactions(self):
-        member = testing_member
-        member.paused_date = None
-        member.expire_date = None
+        testing_user = self.get_user()
+
+        member, _ = models.Member.objects.get_or_create(
+            first_name=testing_user.first_name,
+            preferred_name=testing_user.first_name,
+            last_name=testing_user.last_name,
+            user=testing_user,
+            paused_date=None,
+            expire_date=None
+        )
+
         return member
 
     def test_tally_membership_months_prepaid(self):
@@ -220,6 +231,7 @@ class TestTallyMembership(TestCase):
             models.Transaction.objects.create(
                 amount=0,
                 member_id=member.id,
+                user=member.user,
                 number_of_membership_months=1,
             )
 
@@ -241,6 +253,7 @@ class TestTallyMembership(TestCase):
             models.Transaction.objects.create(
                 amount=0,
                 member_id=member.id,
+                user=member.user,
                 number_of_membership_months=1,
             )
 
@@ -262,6 +275,7 @@ class TestTallyMembership(TestCase):
             models.Transaction.objects.create(
                 amount=0,
                 member_id=member.id,
+                user=member.user,
                 number_of_membership_months=1,
             )
 
@@ -283,6 +297,7 @@ class TestTallyMembership(TestCase):
             models.Transaction.objects.create(
                 amount=0,
                 member_id=member.id,
+                user=member.user,
                 number_of_membership_months=1,
             )
 
@@ -304,6 +319,7 @@ class TestTallyMembership(TestCase):
             models.Transaction.objects.create(
                 amount=0,
                 member_id=member.id,
+                user=member.user,
                 number_of_membership_months=1,
             )
 

--- a/apiserver/apiserver/api/tests.py
+++ b/apiserver/apiserver/api/tests.py
@@ -1,7 +1,3 @@
-import django, sys, os
-os.environ['DJANGO_SETTINGS_MODULE'] = 'apiserver.settings'
-django.setup()
-
 from django.test import TestCase
 import datetime
 from dateutil import relativedelta

--- a/apiserver/apiserver/api/tests.py
+++ b/apiserver/apiserver/api/tests.py
@@ -200,40 +200,6 @@ class TestCalcStatus(TestCase):
         self.assertEqual(status, 'Former Member')
 
 
-class TestFakeMonths(TestCase):
-    def test_fake_missing_membership_months_one_month(self):
-        testing_member.current_start_date = datetime.date(2018, 6, 6)
-        testing_member.expire_date = datetime.date(2018, 7, 6)
-
-        tx, count = utils.fake_missing_membership_months(testing_member)
-
-        self.assertEqual(count, 1)
-
-    def test_fake_missing_membership_months_one_and_half_month(self):
-        testing_member.current_start_date = datetime.date(2018, 6, 1)
-        testing_member.expire_date = datetime.date(2018, 7, 15)
-
-        tx, count = utils.fake_missing_membership_months(testing_member)
-
-        self.assertEqual(count, 1)
-
-    def test_fake_missing_membership_months_one_year(self):
-        testing_member.current_start_date = datetime.date(2018, 6, 6)
-        testing_member.expire_date = datetime.date(2019, 6, 6)
-
-        tx, count = utils.fake_missing_membership_months(testing_member)
-
-        self.assertEqual(count, 12)
-
-    def test_fake_missing_membership_months_same_month(self):
-        testing_member.current_start_date = datetime.date(2018, 6, 6)
-        testing_member.expire_date = datetime.date(2018, 6, 16)
-
-        tx, count = utils.fake_missing_membership_months(testing_member)
-
-        self.assertEqual(count, 0)
-
-
 class TestTallyMembership(TestCase):
     def get_member_clear_transactions(self):
         member = testing_member


### PR DESCRIPTION
Tests were failing so fixed those up:

- Remove `TestFakeMonths` test case. The method it was testing no longer exist so presumably this isnt needed anymore
- Moved test data creation for `TestTallyMembership` into the the testcase itself. I think Django is doing some in memory `QuerySet` for testcases - so the `Transaction`s being created didnt have valid FKs to the test `Member` and `User` when they were created outside the testcase. Putting them all together fixes it. Not sure if we will want to do this long term but reckon it is good enough to get all our tests passing again :+1: 