### PR TITLE
Google calendar support

### DIFF
--- a/webclient/src/Classes.js
+++ b/webclient/src/Classes.js
@@ -464,9 +464,9 @@ export function ICalButtons(props) {
 	};
 
 	const options = [
-		{ key: 'email', icon: 'mail outline', text: 'Email ICS Event', value: 'email', action: handleEmail },
-		{ key: 'download', icon: 'download', text: 'Download ICS Event', value: 'download', action: handleDownload },
-		{ key: 'google', icon: 'google', text: 'Add to Google Calendar', value: 'google', action: addToGoogleCalendar },
+		{ key: 'email', icon: 'mail outline', text: 'Email ICS Event', value: 'Email', action: handleEmail },
+		{ key: 'download', icon: 'download', text: 'Download ICS Event', value: 'Download', action: handleDownload },
+		{ key: 'google', icon: 'google', text: 'Add to Google Calendar', value: 'Google', action: addToGoogleCalendar },
 	];
 
 	// get default option from local storage or default to first item in options list
@@ -497,7 +497,7 @@ export function ICalButtons(props) {
 					loading={loading}
 					onClick={selectedOption.action}
 				>
-					<Icon name={selectedOption.icon} />{selectedOption.text}
+					<Icon name={selectedOption.icon} />{selectedOption.value}
 				</Button>
 				<Dropdown
 					className='button icon'

--- a/webclient/src/Classes.js
+++ b/webclient/src/Classes.js
@@ -453,28 +453,29 @@ export function ICalButtons(props) {
 	const addToGoogleCalendar = (e) => {
 		e.preventDefault();
 		// TODO: fill in URL from clazz properties
-		window.location = 'https://www.google.com/calendar/render?action=TEMPLATE&text=Title&dates=20190227/20190228'
+		window.open('https://www.google.com/calendar/render?action=TEMPLATE&text=Title&dates=20190227/20190228', '_blank');
 	};
 
 	const options = [
-		{ key: 'email', icon: 'mail outline', text: 'Email ICS Event', value: 'email' },
-		{ key: 'download', icon: 'download', text: 'Download ICS Event', value: 'download' },
-		{ key: 'google', icon: 'google', text: 'Add to Google Calendar', value: 'google' },
+		{ key: 'email', icon: 'mail outline', text: 'Email ICS Event', value: 'email', action: handleEmail },
+		{ key: 'download', icon: 'download', text: 'Download ICS Event', value: 'download', action: handleDownload },
+		{ key: 'google', icon: 'google', text: 'Add to Google Calendar', value: 'google', action: addToGoogleCalendar },
 	];
-
-	let selectedOption = options[0];
+	// TODO: get default option from local storage or default to 0
+	const [selectedOption, setOption] = useState(options[0]);
 
 	const onClick = (e, data) => {
-		selectedOption = options.filter(x => x.value === data.value)[0];
-		console.log(selectedOption);
-		// TODO set state here
-		// setState({selectedOption: selectedOption});
-		// TODO: change the Button onClick handler...based on selected option?
+		let newOption = options.filter(x => x.value === data.value)[0];
+		setOption(newOption);
 	};
 
 	return (
 		<Button.Group>
-			<Button onClick={handleDownload}><Icon name={selectedOption.icon} />{selectedOption.text}</Button>
+			<Button 
+				loading={loading}
+				onClick={selectedOption.action}>
+					<Icon name={selectedOption.icon} />{selectedOption.text}
+			</Button>
 			<Dropdown
 				className='button icon'
 		      		floating
@@ -483,6 +484,7 @@ export function ICalButtons(props) {
 		      		trigger={<></>}
 			/>
 		</Button.Group>
+		// TODO: reimplement success prompt
 		/*<>
 			<Button compact onClick={handleDownload}>
 				Download

--- a/webclient/src/Classes.js
+++ b/webclient/src/Classes.js
@@ -501,6 +501,7 @@ export function ICalButtons(props) {
 					onChange={onChange}
 					options={options}
 					trigger={<></>}
+					selectOnBlur={false}
 				/>
 			</Button.Group>
 		}

--- a/webclient/src/Classes.js
+++ b/webclient/src/Classes.js
@@ -450,8 +450,40 @@ export function ICalButtons(props) {
 		});
 	};
 
+	const addToGoogleCalendar = (e) => {
+		e.preventDefault();
+		// TODO: fill in URL from clazz properties
+		window.location = 'https://www.google.com/calendar/render?action=TEMPLATE&text=Title&dates=20190227/20190228'
+	};
+
+	const options = [
+		{ key: 'email', icon: 'mail outline', text: 'Email ICS Event', value: 'email' },
+		{ key: 'download', icon: 'download', text: 'Download ICS Event', value: 'download' },
+		{ key: 'google', icon: 'google', text: 'Add to Google Calendar', value: 'google' },
+	];
+
+	let selectedOption = options[0];
+
+	const onClick = (e, data) => {
+		selectedOption = options.filter(x => x.value === data.value)[0];
+		console.log(selectedOption);
+		// TODO set state here
+		// setState({selectedOption: selectedOption});
+		// TODO: change the Button onClick handler...based on selected option?
+	};
+
 	return (
-		<>
+		<Button.Group>
+			<Button onClick={handleDownload}><Icon name={selectedOption.icon} />{selectedOption.text}</Button>
+			<Dropdown
+				className='button icon'
+		      		floating
+		      		onChange={onClick}
+		      		options={options}
+		      		trigger={<></>}
+			/>
+		</Button.Group>
+		/*<>
 			<Button compact onClick={handleDownload}>
 				Download
 			</Button>
@@ -463,7 +495,7 @@ export function ICalButtons(props) {
 				</Button>
 			}
 			{error && <span>Error.</span>}
-		</>
+		</>*/
 	);
 };
 

--- a/webclient/src/Classes.js
+++ b/webclient/src/Classes.js
@@ -470,21 +470,17 @@ export function ICalButtons(props) {
 	];
 
 	// get default option from local storage or default to first item in options list
-	const pref = 'calendarPreference';
-	let defaultSelection =  options[0];
-	let savedPreference = localStorage.getItem(pref);
-	if (savedPreference != null) {
-		defaultSelection = options.filter(x => x.value === savedPreference)[0];
-	}
+	const calendarValue = localStorage.getItem('calendarPreference') || 'Email';
+	const defaultOption = options.find(x => x.value === calendarValue);
 
-	const [selectedOption, setOption] = useState(defaultSelection);
+	const [selectedOption, setOption] = useState(defaultOption);
 
-	const onClick = (e, data) => {
-		let newOption = options.filter(x => x.value === data.value)[0];
+	const onChange = (e, data) => {
+		const newOption = options.find(x => x.value === data.value);
 		setOption(newOption);
 
 		// set the option as users preference
-		localStorage.setItem(pref, newOption.value);
+		localStorage.setItem('calendarPreference', newOption.value);
 	};
 
 	return (
@@ -502,7 +498,7 @@ export function ICalButtons(props) {
 				<Dropdown
 					className='button icon'
 					floating
-					onChange={onClick}
+					onChange={onChange}
 					options={options}
 					trigger={<></>}
 				/>

--- a/webclient/src/Classes.js
+++ b/webclient/src/Classes.js
@@ -452,8 +452,15 @@ export function ICalButtons(props) {
 
 	const addToGoogleCalendar = (e) => {
 		e.preventDefault();
-		// TODO: fill in URL from clazz properties
-		window.open('https://www.google.com/calendar/render?action=TEMPLATE&text=Title&dates=20190227/20190228', '_blank');
+
+		// construct and set the dates format that google calendar links require
+		let starttime = moment(clazz.datetime);
+		let endtime = starttime.clone().add(1, 'hour');
+		const datestringfmt = 'YYYYMMDDTkkmmss';
+		let dates = `${starttime.format(datestringfmt)}/${endtime.format(datestringfmt)}`
+
+		// send user to google calendar
+		window.location = `https://www.google.com/calendar/render?action=TEMPLATE&text=${clazz.course_data.name}&dates=${dates}`;
 	};
 
 	const options = [
@@ -461,43 +468,44 @@ export function ICalButtons(props) {
 		{ key: 'download', icon: 'download', text: 'Download ICS Event', value: 'download', action: handleDownload },
 		{ key: 'google', icon: 'google', text: 'Add to Google Calendar', value: 'google', action: addToGoogleCalendar },
 	];
-	// TODO: get default option from local storage or default to 0
-	const [selectedOption, setOption] = useState(options[0]);
+
+	// get default option from local storage or default to first item in options list
+	const pref = 'calendarPreference';
+	let defaultSelection =  options[0];
+	let savedPreference = localStorage.getItem(pref);
+	if (savedPreference != null) defaultSelection = options.filter(x => x.value === savedPreference)[0];
+
+	const [selectedOption, setOption] = useState(defaultSelection);
 
 	const onClick = (e, data) => {
 		let newOption = options.filter(x => x.value === data.value)[0];
 		setOption(newOption);
+
+		// set the option as users preference
+		localStorage.setItem(pref, newOption.value);
 	};
 
 	return (
-		<Button.Group>
-			<Button 
-				loading={loading}
-				onClick={selectedOption.action}>
-					<Icon name={selectedOption.icon} />{selectedOption.text}
-			</Button>
-			<Dropdown
-				className='button icon'
-		      		floating
-		      		onChange={onClick}
-		      		options={options}
-		      		trigger={<></>}
-			/>
-		</Button.Group>
-		// TODO: reimplement success prompt
-		/*<>
-			<Button compact onClick={handleDownload}>
-				Download
-			</Button>
-			{success ?
-				<span>&nbsp;&nbsp;Sent!</span>
-			:
-				<Button compact loading={loading} onClick={handleEmail}>
-					Email
+		<>
+		{success ?
+			<span>&nbsp;&nbsp;Sent!</span>
+		:
+			<Button.Group>
+				<Button
+					loading={loading}
+					onClick={selectedOption.action}>
+						<Icon name={selectedOption.icon} />{selectedOption.text}
 				</Button>
-			}
-			{error && <span>Error.</span>}
-		</>*/
+				<Dropdown
+					className='button icon'
+					floating
+					onChange={onClick}
+					options={options}
+					trigger={<></>}
+				/>
+			</Button.Group>
+		}
+		</>
 	);
 };
 

--- a/webclient/src/Classes.js
+++ b/webclient/src/Classes.js
@@ -473,7 +473,9 @@ export function ICalButtons(props) {
 	const pref = 'calendarPreference';
 	let defaultSelection =  options[0];
 	let savedPreference = localStorage.getItem(pref);
-	if (savedPreference != null) defaultSelection = options.filter(x => x.value === savedPreference)[0];
+	if (savedPreference != null) {
+		defaultSelection = options.filter(x => x.value === savedPreference)[0];
+	}
 
 	const [selectedOption, setOption] = useState(defaultSelection);
 
@@ -493,8 +495,9 @@ export function ICalButtons(props) {
 			<Button.Group>
 				<Button
 					loading={loading}
-					onClick={selectedOption.action}>
-						<Icon name={selectedOption.icon} />{selectedOption.text}
+					onClick={selectedOption.action}
+				>
+					<Icon name={selectedOption.icon} />{selectedOption.text}
 				</Button>
 				<Dropdown
 					className='button icon'

--- a/webclient/src/light.css
+++ b/webclient/src/light.css
@@ -99,6 +99,12 @@ body {
 	padding-top: 1rem;
 }
 
+.ui.floating.dropdown.button.icon {
+	border-left: 1px;
+	border-left-color: #c0c1c2;
+	border-left-style: solid;
+}
+
 .attendance-row {
 	margin-top: 1rem;
 }


### PR DESCRIPTION
For whatever reason, I have a hell of a time adding classes to my calendar on my iPhone. I can't figure out how to get `ics` files to open in google calendar so I did this instead:

[Screencast from 07-10-2022 12:18:03 PM.webm](https://user-images.githubusercontent.com/11947658/178157164-cfc095a2-1584-4cf5-ae93-65030136806e.webm)

- Added a third option - adding straight to google calendar using their URL template functionality. [Explained here](https://support.google.com/calendar/thread/107797661/url-to-add-event-to-calendar?hl=en)
- Instead of adding a third button, switch the calendar invite preference into a [Button with dropdown](https://react.semantic-ui.com/modules/dropdown/#types-floating). Semantic UI is nice, it has been growing on me
- Added a preference saving mechanic using `localStorage`. Whatever the user selects as their option will persist across page reloads. 

Let me know if you detect any bugs or weirdness. Happy to fix