### PR TITLE
Add new tool - general process improvements

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,3 +4,7 @@ root = true
 [*]
 indent_style = tab
 indent_size = 4
+
+[*.py]
+indent_style = space
+indent_size = 4

--- a/apiserver/apiserver/api/utils_mediawiki.py
+++ b/apiserver/apiserver/api/utils_mediawiki.py
@@ -152,6 +152,8 @@ TBD
                 rollback(**kwargs)
             except Exception as rollback_error:
                 logger.error('Rollback failed: %s', rollback_error)
+            finally:
+                raise e
 
 def add_to_gallery(tool_id, photo_name, tool_name, PAGE_NAME='Tools_we_have', NEW_TOOL_SECTION=None, credit=''):
     '''Add a tool to the gallery page'''

--- a/apiserver/apiserver/api/utils_mediawiki.py
+++ b/apiserver/apiserver/api/utils_mediawiki.py
@@ -56,6 +56,11 @@ def create_tool_page(form_data):
 
     tool_id = get_next_tool_id(site)
 
+    # collect calls for rolling back this operation incase it fails partway
+    # each rollback item is a tuple: (rollback_function, dict of kwargs)
+    # each rollback function will be called in the event of an Exception
+    rollbacks = [ ]
+
     photo_name = 'NoImage.png'
     if 'photo' in form_data and form_data['photo']:
         # upload photo
@@ -63,6 +68,7 @@ def create_tool_page(form_data):
         photo_extn = photo_data.content_type.replace('image/', '')
         photo_name = f'{tool_id}.{photo_extn}'
         site.upload(photo_data, photo_name, 1, f'Photo of tool {tool_id}')
+        # TODO: implement rollback
 
     # make a copy of form_data specifically avoiding the 'photo' field
     # if photo is provided, is an I/O object that is already closed because of the above 
@@ -105,21 +111,27 @@ TBD
 TBD
 
 ==Links==
-{form_copy.get('links', 'TBD') or 'TBD'}
+{ form_copy['links'] if 'links' in form_copy else 'TBD' }
 '''
 
     name = f'{form_copy["toolname"]} ({form_copy["model"]}) ID:{tool_id}'
 
     # create tool page
     page = site.pages[name]
+    # TODO: credit uploader
     page.save(body, summary='Creating new tool page')
+    # TODO: implement rollback
 
     # create redirect page
     redirect = site.pages[tool_id]
     redirect.save('#REDIRECT [[' + name + ']]{{id/after-redirect}}')
+    # TODO: implement rollback
 
     # TODO: add to gallery
     # leaving unimplemented atm because idk how locate the right section of the gallery
+    # here's the template to adapt:
+    # File:197.jpeg|link=197|[[Vacuum,_13_gal_1.5_HP_(Shop_Vac_3333.0E)_ID:197]]
+    # TODO: implement rollback
 
     tool_url = 'https://' + secrets.WIKI_ENDPOINT + f'/{tool_id}'
 

--- a/apiserver/apiserver/api/views.py
+++ b/apiserver/apiserver/api/views.py
@@ -2247,6 +2247,23 @@ class ToolsViewSet(Base, Create, Destroy):
 
         return Response(status=drfstatus.HTTP_404_NOT_FOUND)
 
+    @action(detail=False, methods=['get'], url_path='categories')
+    def categories(self, request):
+        categories = [
+                # copy the ToC from https://wiki.protospace.ca/Tools_we_have
+                '1 3D Printer',
+                '2 Laser Cutter',
+                '3 Wood/Plastic CNC',
+                '4 Automotive tool',
+                '5 Electronics equipment',
+                '6 Metalworking tool',
+                '7 Woodworking and plasticworking tool',
+                '8 Textile, Leather, Vinyl, and Media tool',
+                '9 Measuring and inspection tool',
+                '10 Miscellaneous or other',
+                ]
+        return Response([{'value': item.split(' ', 1)[0], 'text': item.split(' ', 1)[1]} for item in categories])
+
 @api_view()
 def null_view(request, *args, **kwargs):
     raise Http404

--- a/apiserver/apiserver/api/views.py
+++ b/apiserver/apiserver/api/views.py
@@ -2226,7 +2226,7 @@ class ToolsViewSet(Base, Create, Destroy):
 
     def create(self, request):
         try:
-            tool_url = utils_mediawiki.create_tool_page(request.data)
+            tool_url = utils_mediawiki.create_tool_page(request.data, user=request.user.username)
             return Response({'toolUrl': tool_url}, status=drfstatus.HTTP_201_CREATED)
         except Exception as e:
             logger.exception('Create Tool view - {} - {}'.format(e.__class__.__name__, str(e)))

--- a/apiserver/apiserver/api/views.py
+++ b/apiserver/apiserver/api/views.py
@@ -2230,6 +2230,7 @@ class ToolsViewSet(Base, Create, Destroy):
             return Response({'toolUrl': tool_url}, status=drfstatus.HTTP_201_CREATED)
         except Exception as e:
             logger.exception('Create Tool view - {} - {}'.format(e.__class__.__name__, str(e)))
+            # TODO: alert via Telegram
             return Response({'error': str(e)}, status=drfstatus.HTTP_500_INTERNAL_SERVER_ERROR)
 
     def destroy(self, request, *args, **kwargs):

--- a/webclient/src/AddNewTool.js
+++ b/webclient/src/AddNewTool.js
@@ -267,6 +267,7 @@ export function AddNewTool(props) {
 					</Form.Field>
 
 					<Button
+						// TODO: implement validation as per LoginSignup
 						type='submit'
 						onClick={postTool}
 						primary

--- a/webclient/src/AddNewTool.js
+++ b/webclient/src/AddNewTool.js
@@ -263,6 +263,8 @@ export function AddNewTool(props) {
 							placeholder='Add hyperlinks for pages that provide more detail about this tool'
 							name='links'
 							onChange={handleChange}
+							// TODO: select category for where to insert in gallery
+							// TODO: section for general/misc notes
 						/>
 					</Form.Field>
 

--- a/webclient/src/AddNewTool.js
+++ b/webclient/src/AddNewTool.js
@@ -33,6 +33,18 @@ export function AddNewTool(props) {
 	const [toolUrl, setToolUrl] = useState('');
 	const [photoKey, setPhotoKey] = useState(Date.now());
 	const [photoProblem, setPhotoProblem] = useState(false)
+	const [categoryOptions, setCategoryOptions] = useState([])
+
+	useEffect(() => {
+		requester('/tools/categories/', 'GET', token)
+		.then(res => {
+			setCategoryOptions(res);
+			handleChange(null, { name: 'category', value: res[res.length - 1].value });
+		})
+		.catch(err => {
+			console.log(err);
+		});
+	}, [token]);
 
 	const handleChange = (e, v) => setFormData({ ...formData, [v.name]: v.value });
 
@@ -263,13 +275,27 @@ export function AddNewTool(props) {
 							placeholder='Add hyperlinks for pages that provide more detail about this tool'
 							name='links'
 							onChange={handleChange}
-							// TODO: select category for where to insert in gallery
-							// TODO: section for general/misc notes
+						/>
+					</Form.Field>
+
+					<Form.Field>
+						<label>What category best describes this tool?</label>
+						<p>This determines where the tool appears in the <a href='https://wiki.protospace.ca/Tools_we_have' target='_blank'>Gallery</a></p>
+						<Dropdown
+							placeholder=''
+							fluid
+							selection
+							options={categoryOptions}
+							required
+							name='category'
+							onChange={handleChange}
+							value={formData.category}
 						/>
 					</Form.Field>
 
 					<Button
 						// TODO: implement validation as per LoginSignup
+						// TODO: section for general/misc notes
 						type='submit'
 						onClick={postTool}
 						primary


### PR DESCRIPTION
Features added in this PR:
- credit user who is creating page
- rollback in case of failure (i.e. if something goes wrong, make the corresponding API calls to revert changes)
- add new tool to gallery. include field in AddNewTool form for user to select which section of the gallery to add tool to
- myriad of small bug fixes
- reorder operations for creating tool page, should reduce possibilities of collision by making the redirect page first

Not included:
- form validation
- notify of upload errors via Telegram