### PR TITLE
Fix: restrict autoscan field to admin only

### DIFF
--- a/apiserver/apiserver/api/views.py
+++ b/apiserver/apiserver/api/views.py
@@ -945,6 +945,8 @@ class StatsViewSet(viewsets.ViewSet, List):
         if not user.is_authenticated:
             stats.pop('alarm', None)
             stats.pop('autoscan', None)
+        elif not user.is_admin_director:
+            stats.pop('autoscan', None)
 
         stats['at_protospace'] = utils.is_request_from_protospace(request)
 


### PR DESCRIPTION
Before: /stats/ exposed the 'autoscan' field (raw RFID hex) to all logged-in members (including non-paid new members). 
This meant a simple polling script could collect newly vetted card numbers during onboarding.

After: autoscan is now only included in the stats response for staff users, 
preventing leakage of sensitive card IDs.