### PR TITLE
Front end image-type enforcement

### DIFF
--- a/webclient/src/Account.js
+++ b/webclient/src/Account.js
@@ -286,7 +286,7 @@ export function AccountForm(props) {
 				label='Member Photo'
 				name='photo'
 				type='file'
-				accept='image/*'
+				accept='image/png, image/jpeg'
 				onChange={handleUpload}
 			/>}
 


### PR DESCRIPTION
Back-end current only allows png and jpeg formats, but the front-end allows users to select any kind of image file. This causes errors on upload to the server.

Change ensures that users are only able to select supported image formats for upload.