### PR TITLE
Add Docker Compose setup for local development

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+.git
+*.pyc
+__pycache__
+*.sqlite3
+node_modules
+webclient/build
+apiserver/env
+apiserver/data/static
+apiserver/backups
+authserver/env
+ldapserver/env
+*.egg-info
+.DS_Store
+*/secrets.py

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,69 @@
+# Noiseport (Spaceport)
+
+Member portal for Noisebridge hackerspace. Tracks membership, courses, training, access cards, storage, and community resources. Originally built for Calgary Protospace.
+
+## Tech Stack
+
+- **Backend**: Django 3.1 + Django REST Framework (`/apiserver`), SQLite, memcached
+- **Frontend**: React 16 (CRA) + Semantic UI React (`/webclient`), Yarn
+- **Auth**: Token-based (rest_auth), OIDC provider
+- **Other services**: Auth server (`/authserver`), LDAP server (`/ldapserver`)
+
+## Development
+
+```bash
+# Backend
+cd apiserver
+source env/bin/activate
+DEBUG=true BINDALL=true python manage.py runserver 0.0.0.0:8000
+
+# Frontend
+cd webclient
+HOST=0.0.0.0 yarn start  # port 3000
+```
+
+First registered user is auto-granted admin.
+
+### Docker (recommended)
+
+```bash
+docker compose up              # starts apiserver :8000, webclient :3000, memcached
+docker compose up --build      # rebuild after dependency changes
+docker compose --profile auth up   # include authserver (needs external MediaWiki/Discourse)
+docker compose --profile ldap up   # include ldapserver (needs external AD)
+```
+
+Frontend auto-detects the API at `localhost:8000` via port detection in `webclient/src/utils.js`.
+
+## Testing
+
+```bash
+python manage.py test apiserver.api    # backend
+cd webclient && yarn test              # frontend
+```
+
+## Code Conventions
+
+- Tabs for indentation (4 spaces for Python per .editorconfig)
+- Single quotes in JavaScript (.prettierrc)
+- Backend: ViewSets + serializers + custom permissions (IsObjOwnerOrAdmin, IsAdmin, etc.)
+- Frontend: mix of class and functional components, localStorage for state, `requester()` utility for API calls
+- Trailing slashes required on API URLs
+- Timezone: stored UTC, displayed America/Edmonton. Use `today_alberta_tz()` / `now_alberta_tz()`
+
+## Key Directories
+
+- `apiserver/api/models.py` — all models (Member, Transaction, Card, Course, Session, Training, etc.)
+- `apiserver/api/views.py` — all ViewSets
+- `apiserver/api/serializers.py` — DRF serializers
+- `apiserver/apiserver/urls.py` — URL routing
+- `webclient/src/` — React components (Home, Members, Training, Courses, Charts, etc.)
+- `scripts/` — migration and management scripts
+- `docs/` — project documentation
+
+## Management Commands (Cron)
+
+- `run_minutely` — server checks, shopping/maintenance lists
+- `run_hourly` — membership status updates, email notifications
+- `run_daily` — backups, stats calculation
+- `run_weekly` — report generation

--- a/apiserver/Dockerfile
+++ b/apiserver/Dockerfile
@@ -1,0 +1,26 @@
+FROM python:3.11-slim
+
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    gcc \
+    libc6-dev \
+    libffi-dev \
+    libjpeg-dev \
+    zlib1g-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN uv pip install --system "setuptools<69" wheel && \
+    uv pip install --system --no-build-isolation -r requirements.txt
+
+COPY . .
+
+RUN test -f apiserver/secrets.py || cp apiserver/secrets.py.example apiserver/secrets.py
+RUN mkdir -p data
+
+EXPOSE 8000
+
+CMD ["python", "manage.py", "runserver", "0.0.0.0:8000"]

--- a/apiserver/apiserver/settings.py
+++ b/apiserver/apiserver/settings.py
@@ -139,7 +139,7 @@ DATABASES = {
 CACHES = {
     'default': {
         'BACKEND': 'django.core.cache.backends.memcached.MemcachedCache',
-        'LOCATION': '127.0.0.1:11211',
+        'LOCATION': os.environ.get('MEMCACHED_LOCATION', '127.0.0.1:11211'),
         'TIMEOUT': None,
     }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,56 @@
+services:
+  memcached:
+    image: memcached:1.6-alpine
+
+  apiserver:
+    build: ./apiserver
+    ports:
+      - "8000:8000"
+    volumes:
+      - ./apiserver:/app
+      - ./apiserver/data:/app/data
+    environment:
+      - DEBUG=true
+      - BINDALL=true
+      - MEMCACHED_LOCATION=memcached:11211
+    depends_on:
+      - memcached
+    command: >
+      sh -c "
+        test -f apiserver/secrets.py || cp apiserver/secrets.py.example apiserver/secrets.py &&
+        python manage.py migrate --run-syncdb &&
+        python manage.py runserver 0.0.0.0:8000
+      "
+
+  webclient:
+    build: ./webclient
+    ports:
+      - "3000:3000"
+    volumes:
+      - ./webclient/src:/app/src
+      - ./webclient/public:/app/public
+    environment:
+      - HOST=0.0.0.0
+      - CHOKIDAR_USEPOLLING=true
+      - CI=false
+      - BROWSER=none
+    stdin_open: true
+    tty: true
+
+  authserver:
+    build: ./authserver
+    ports:
+      - "5050:5000"
+    volumes:
+      - ./authserver:/app
+    profiles:
+      - auth
+
+  ldapserver:
+    build: ./ldapserver
+    ports:
+      - "5051:5000"
+    volumes:
+      - ./ldapserver:/app
+    profiles:
+      - ldap

--- a/webclient/Dockerfile
+++ b/webclient/Dockerfile
@@ -1,0 +1,16 @@
+FROM node:14-alpine
+
+WORKDIR /app
+
+COPY package.json yarn.lock ./
+RUN yarn install --frozen-lockfile
+
+COPY . .
+
+EXPOSE 3000
+
+ENV HOST=0.0.0.0
+ENV CI=false
+ENV BROWSER=none
+
+CMD ["yarn", "start"]


### PR DESCRIPTION
Dockerfiles for apiserver (Python 3.11 + uv) and webclient (Node 14), docker-compose.yml with memcached, env-based MEMCACHED_LOCATION in settings.py, .dockerignore, and CLAUDE.md project docs.

I found initial setup more toil steps than I wanted, so this branch works toward 12factor advice.  On `.dockerignore`, apparently the risk is these files can be included in build context, then devs share secrets.

On `CLAUDE.md` file, it seems like a great llm (& human) intro. Happy to call it something else, `AGENTS.md` or `DEV-QUICKSTART.md` (and I wish there was a convention to use a well known subdirectory).