### PR TITLE
Add initial Robot Framework public smoke tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 
 docs/.obsidian/workspace.json
 guidebook/content/.obsidian/workspace.json
+results/
+__pycache__/
+.DS_Store

--- a/tests/robot/README.md
+++ b/tests/robot/README.md
@@ -1,0 +1,46 @@
+# Spaceport Robot Framework Tests
+
+This directory contains an initial Robot Framework test scaffold for the Spaceport portal using the Browser library.
+
+## Scope
+
+This first PR focuses on:
+- local Browser-library test setup
+- shared Robot resources for navigation, waits, assertions, and screenshots
+- page resources for the public landing page and public messaging area
+- one smoke suite covering core public-page rendering checks and basic navigation
+- helper Python libraries for Faker-based test data and CSV-driven expansion in later PRs
+
+## Layout
+
+- `tests/robot/pages/` page resources
+- `tests/robot/resources/` shared Robot keywords, variables, and Python helper libraries
+- `tests/robot/tests/` Robot suites
+- `results/` local execution output
+
+## Requirements
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r tests/robot/requirements.txt
+rfbrowser init
+```
+
+## Running tests
+
+```bash
+robot -d results tests/robot/tests
+robot -d results -i smoke tests/robot/tests
+robot -d results tests/robot/tests/smoke.robot
+```
+
+## Notes
+
+- The suite currently targets a local Spaceport instance at `http://localhost:3000`.
+- This PR is intentionally limited to smoke coverage and reusable test infrastructure.
+- Login, signup, CSV-driven suites, and broader regression coverage can follow in later PRs.
+
+## Reliability notes
+
+Some public-page controls still require position-based selectors, especially in the messaging area. Adding stable `data-testid` attributes in the app would make these tests more robust.

--- a/tests/robot/pages/LandingPage.resource
+++ b/tests/robot/pages/LandingPage.resource
@@ -1,0 +1,46 @@
+*** Settings ***
+Resource   ../resources/Common.resource
+
+*** Keywords ***
+Landing Page Should Be Visible
+    Wait Until Spaceport Page Ready
+
+Quick Links Should Be Visible
+    Page Should Contain Text    Quick Links
+    Page Should Contain Text    Main Website
+    Page Should Contain Text    Protospace Wiki
+    Page Should Contain Text    Forum (Spacebar)
+
+Public Stats Should Be Visible
+    Page Should Contain Text    Protospace Stats
+    Page Should Contain Text    Member count:
+    Page Should Contain Text    Card scans today:
+    Page Should Contain Text    Alarm status:
+    Page Should Contain Text    Hosting status:
+    Page Should Contain Text    Next class:
+    Page Should Contain Text    Last class:
+
+Forgot Password Link Should Navigate
+    Click When Ready    text=Forgot Password
+    Wait For Url Contains    /password/reset/
+
+Guide Link Should Navigate
+    Click When Ready    text=Guide
+    Wait For Url Contains    /guide/
+
+Charts Link Should Navigate
+    Click When Ready    text=[charts]
+    Wait For Url Contains    /charts
+
+Gallery Requires Login Message Should Be Visible
+    Page Should Contain Text    Please login
+    Page Should Contain Text    [gallery]
+
+Footer And Support Links Should Be Visible
+    Page Should Contain Text    Created and hosted by Protospace members for Protospace members.
+    Page Should Contain Text    View the source code and license on GitHub.
+    Page Should Contain Text    info@protospace.ca
+
+Unauthorized Operational Statuses Should Be Visible
+    Page Should Contain Text    Alarm status: Unauthorized
+    Page Should Contain Text    Hosting status: Unauthorized

--- a/tests/robot/pages/PublicMessagingPage.resource
+++ b/tests/robot/pages/PublicMessagingPage.resource
@@ -1,0 +1,17 @@
+*** Settings ***
+Resource   ../resources/Common.resource
+
+*** Keywords ***
+Public Messaging Inputs Should Be Visible
+    Page Should Contain Text    Send a message to the sign + Vestaboard:
+    Page Should Contain Text    Send a message to the Vestaboard only:
+
+Submit Sign And Vestaboard Message
+    [Arguments]    ${text}
+    Fill Text Safely    input >> nth=7    ${text}
+    Click When Ready    text=Submit >> nth=0
+
+Submit Vestaboard Only Message
+    [Arguments]    ${text}
+    Fill Text Safely    input >> nth=8    ${text}
+    Click When Ready    text=Submit >> nth=1

--- a/tests/robot/requirements.txt
+++ b/tests/robot/requirements.txt
@@ -1,0 +1,3 @@
+robotframework>=7.0
+robotframework-browser>=18.0.0
+faker>=25.0.0

--- a/tests/robot/resources/Common.resource
+++ b/tests/robot/resources/Common.resource
@@ -1,0 +1,49 @@
+*** Settings ***
+Library    Browser
+Library    String
+Resource   Variables.resource
+
+*** Keywords ***
+Open Spaceport Browser
+    New Browser    browser=${BROWSER}    headless=${HEADLESS}
+    New Context
+    New Page    ${BASE_URL}
+    Set Browser Timeout    ${DEFAULT_TIMEOUT}
+
+Close Spaceport Browser
+    Close Browser
+
+Go To Home Page
+    Go To    ${BASE_URL}
+    Wait Until Spaceport Page Ready
+
+Wait Until Spaceport Page Ready
+    Wait For Load State    domcontentloaded
+    Wait For Elements State    text=Quick Links    visible
+    Wait For Elements State    text=Protospace Stats    visible
+
+Wait For Url Contains
+    [Arguments]    ${partial}
+    ${url}=    Get Url
+    Should Contain    ${url}    ${partial}
+
+Click When Ready
+    [Arguments]    ${selector}
+    Wait For Elements State    ${selector}    visible
+    Wait For Elements State    ${selector}    enabled
+    Click    ${selector}
+
+Fill Text Safely
+    [Arguments]    ${selector}    ${value}
+    Wait For Elements State    ${selector}    visible
+    Fill Text    ${selector}    ${value}
+
+Page Should Contain Text
+    [Arguments]    ${text}
+    ${content}=    Get Text    body
+    Should Contain    ${content}    ${text}
+
+Capture Debug Artifact
+    [Arguments]    ${name}=debug
+    ${safe_name}=    Replace String Using Regexp    ${name}    [^A-Za-z0-9._-]    _
+    Take Screenshot    path=results/${safe_name}.png

--- a/tests/robot/resources/Variables.resource
+++ b/tests/robot/resources/Variables.resource
@@ -1,0 +1,10 @@
+*** Variables ***
+${BASE_URL}                 http://localhost:3000
+${BROWSER}                  chromium
+${HEADLESS}                 ${False}
+${DEFAULT_TIMEOUT}          10s
+${VALID_PASSWORD}           TestPass123!
+${SHORT_PASSWORD}           short1!
+${MESSAGE_TEXT}             Automated public portal smoke message
+${VESTABOARD_TEXT}          Hello from Robot Framework
+${DRAWING_TEXT}             robot-heart

--- a/tests/robot/tests/smoke.robot
+++ b/tests/robot/tests/smoke.robot
@@ -1,0 +1,38 @@
+*** Settings ***
+Resource    ../pages/LandingPage.resource
+Resource    ../pages/PublicMessagingPage.resource
+Resource    ../resources/Common.resource
+Suite Setup    Open Spaceport Browser
+Suite Teardown    Close Spaceport Browser
+Test Tags    smoke    public    stable
+Test Teardown    Capture Debug Artifact    smoke
+
+*** Test Cases ***
+Public Landing Page Renders Core Sections
+    Go To Home Page
+    Landing Page Should Be Visible
+    Quick Links Should Be Visible
+    Public Stats Should Be Visible
+    Unauthorized Operational Statuses Should Be Visible
+    Footer And Support Links Should Be Visible
+    Gallery Requires Login Message Should Be Visible
+
+Public Messaging Areas Render
+    Go To Home Page
+    Landing Page Should Be Visible
+    Public Messaging Inputs Should Be Visible
+
+Forgot Password Link Navigates
+    Go To Home Page
+    Landing Page Should Be Visible
+    Forgot Password Link Should Navigate
+
+Guide Link Navigates
+    Go To Home Page
+    Landing Page Should Be Visible
+    Guide Link Should Navigate
+
+Protected Cards Page Requires Login
+    Go To    ${BASE_URL}/cards
+    Page Should Contain Text    You must login before you can do that!
+    Page Should Contain Text    Visit our login page, then try again.


### PR DESCRIPTION
## Summary

This PR adds an initial Robot Framework smoke test scaffold for the public Spaceport portal.

## Included

- .gitignore coverage for generated test artifacts
- shared Browser-based Robot helpers
- landing page page-object resource
- public messaging page-object resource
- initial smoke suite for public landing-page rendering and basic public navigation
- README and requirements for local setup

## Verified

Ran successfully from repo root with:

```bash
robot -d results tests/robot/tests/smoke.robot
```

## Not included

This PR intentionally excludes:
- login-specific page objects
- broader regression or authenticated workflows