### PR TITLE
Add Special Members Meeting to classification of meeting instead of regular class (ID 478)

### DIFF
--- a/apiserver/apiserver/api/management/commands/run_hourly.py
+++ b/apiserver/apiserver/api/management/commands/run_hourly.py
@@ -77,7 +77,7 @@ class Command(BaseCommand):
                 self.stdout.write('    Is cancelled, skipping.')
                 continue
 
-            if session.course.id in [317, 273, 413]:
+            if session.course.id in [317, 273, 413, 478]:
                 self.stdout.write('    Is members meeting or cleanup, skipping.')
                 continue
 

--- a/apiserver/apiserver/api/management/commands/run_hourly.py
+++ b/apiserver/apiserver/api/management/commands/run_hourly.py
@@ -136,7 +136,7 @@ class Command(BaseCommand):
                 self.stdout.write('    Is cancelled, skipping.')
                 continue
 
-            if session.course.id in [317, 273, 413]:
+            if session.course.id in [317, 273, 413, 478]:
                 self.stdout.write('    Is members meeting or cleanup, skipping.')
                 continue
 

--- a/apiserver/apiserver/api/utils_stats.py
+++ b/apiserver/apiserver/api/utils_stats.py
@@ -65,10 +65,10 @@ def calc_next_events():
     sessions = models.Session.objects
 
     # TODO, go by tag?
-    member_meeting = sessions.filter(is_cancelled=False, course__in=[317, 413], datetime__gte=now()).order_by('datetime').first()
+    member_meeting = sessions.filter(is_cancelled=False, course__in=[317, 413, 478], datetime__gte=now()).order_by('datetime').first()
     monthly_clean = sessions.filter(is_cancelled=False, course=273, datetime__gte=now()).first()
-    next_class = sessions.exclude(course__in=[317, 413, 273]).filter(is_cancelled=False, datetime__gte=now()).order_by('datetime').first()
-    prev_class = sessions.exclude(course__in=[317, 413, 273]).filter(is_cancelled=False, datetime__lte=now()).order_by('datetime').last()
+    next_class = sessions.exclude(course__in=[317, 413, 273, 478]).filter(is_cancelled=False, datetime__gte=now()).order_by('datetime').first()
+    prev_class = sessions.exclude(course__in=[317, 413, 273, 478]).filter(is_cancelled=False, datetime__lte=now()).order_by('datetime').last()
 
     if member_meeting:
         cache.set('next_meeting', member_meeting.datetime)

--- a/webclient/src/utils.js
+++ b/webclient/src/utils.js
@@ -19,7 +19,7 @@ export const isAdmin = (user) => user.is_staff || user.member.is_director || use
 export const isInstructor = (user) => isAdmin(user) || user.member.is_instructor;
 
 export const getInstructor = (x) => {
-	if (x.course === 413 || x.course === 317 || x.course === 273) {
+	if (x.course === 413 || x.course === 317 || x.course === 273 || x.course === 478) {
 		return 'Protospace';
 	} else {
 		return <Link to={'/members/'+x.instructor_id}>{x.instructor_name}</Link>;
@@ -27,7 +27,7 @@ export const getInstructor = (x) => {
 };
 
 export const getInstructorDiscourseLink = (x) => {
-	if (x.course === 413 || x.course === 317 || x.course === 273) {
+	if (x.course === 413 || x.course === 317 || x.course === 273 || x.course === 478) {
 		return false;
 	} else if (!x.instructor_discourse) {
 		return false;


### PR DESCRIPTION
Special Members Meetings (ID 478) appear as a regular class, show instructor name of who scheduled, don't trigger "Next Members Meeting:", etc. This push includes that ID in all of the checks for members meetings.