### PR TITLE
Reapply corrected changes

### DIFF
--- a/tests/robot/pages/LandingPage.resource
+++ b/tests/robot/pages/LandingPage.resource
@@ -29,7 +29,7 @@ Guide Link Should Navigate
     Wait For Url Contains    /guide/
 
 Charts Link Should Navigate
-    Click When Ready    text=[charts]
+    Click When Ready    a:has-text("[charts]")
     Wait For Url Contains    /charts
 
 Gallery Requires Login Message Should Be Visible

--- a/tests/robot/pages/LandingPage.resource
+++ b/tests/robot/pages/LandingPage.resource
@@ -29,7 +29,7 @@ Guide Link Should Navigate
     Wait For Url Contains    /guide/
 
 Charts Link Should Navigate
-    Click When Ready    a:has-text("[charts]")
+    Click When Ready    text=[charts]
     Wait For Url Contains    /charts
 
 Gallery Requires Login Message Should Be Visible

--- a/tests/robot/pages/PublicMessagingPage.resource
+++ b/tests/robot/pages/PublicMessagingPage.resource
@@ -8,10 +8,10 @@ Public Messaging Inputs Should Be Visible
 
 Submit Sign And Vestaboard Message
     [Arguments]    ${text}
-    Fill Text Safely    input >> nth=7    ${text}
-    Click When Ready    text=Submit >> nth=0
+    Fill Text Safely    [data-testid="sign-and-vestaboard-input"]    ${text}
+    Click When Ready    [data-testid="sign-and-vestaboard-submit"]
 
 Submit Vestaboard Only Message
     [Arguments]    ${text}
-    Fill Text Safely    input >> nth=8    ${text}
-    Click When Ready    text=Submit >> nth=1
+    Fill Text Safely    [data-testid="vestaboard-only-input"]    ${text}
+    Click When Ready    [data-testid="vestaboard-only-submit"]

--- a/tests/robot/resources/Common.resource
+++ b/tests/robot/resources/Common.resource
@@ -19,8 +19,7 @@ Go To Home Page
 
 Wait Until Spaceport Page Ready
     Wait For Load State    domcontentloaded
-    Wait For Elements State    text=Quick Links    visible
-    Wait For Elements State    text=Protospace Stats    visible
+    Wait For Elements State    [data-testid="home-stats-section"]    visible
 
 Wait For Url Contains
     [Arguments]    ${partial}
@@ -40,8 +39,7 @@ Fill Text Safely
 
 Page Should Contain Text
     [Arguments]    ${text}
-    ${content}=    Get Text    body
-    Should Contain    ${content}    ${text}
+    Wait For Elements State    text=${text}    visible
 
 Capture Debug Artifact
     [Arguments]    ${name}=debug

--- a/tests/robot/resources/Variables.resource
+++ b/tests/robot/resources/Variables.resource
@@ -1,9 +1,9 @@
 *** Variables ***
 ${BASE_URL}                 http://localhost:3000
 ${BROWSER}                  chromium
-${HEADLESS}                 ${False}
+${HEADLESS}                 ${True}
 ${DEFAULT_TIMEOUT}          10s
-${VALID_PASSWORD}           TestPass123!
+${VALID_PASSWORD}           %{TEST_PASSWORD=TestPass123!}
 ${SHORT_PASSWORD}           short1!
 ${MESSAGE_TEXT}             Automated public portal smoke message
 ${VESTABOARD_TEXT}          Hello from Robot Framework

--- a/tests/robot/setup.sh
+++ b/tests/robot/setup.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+echo "Installing Python dependencies..."
+pip install -r requirements.txt
+
+echo "Initialising rfbrowser Playwright browsers..."
+rfbrowser init
+
+echo "Setup complete. Run tests with:"
+echo "  robot -d results tests/"
+echo "  robot -d results -i smoke tests/"

--- a/tests/robot/tests/smoke.robot
+++ b/tests/robot/tests/smoke.robot
@@ -5,7 +5,7 @@ Resource    ../resources/Common.resource
 Suite Setup    Open Spaceport Browser
 Suite Teardown    Close Spaceport Browser
 Test Tags    smoke    public    stable
-Test Teardown    Capture Debug Artifact    smoke
+Test Teardown    Run Keyword If Test Failed    Capture Debug Artifact    ${TEST NAME}
 
 *** Test Cases ***
 Public Landing Page Renders Core Sections

--- a/webclient/src/Home.js
+++ b/webclient/src/Home.js
@@ -171,7 +171,7 @@ function MemberInfo(props) {
 									<Link to={'/transactions/'+x.id}>{moment(x.date).format('ll')}</Link>
 								</Table.Cell>
 								<Table.Cell>{x.account_type}</Table.Cell>
-								<Table.Cell>{x.protocoin !== '0.00' ? '₱ ' + x.protocoin : '$ ' + x.amount}</Table.Cell>
+								<Table.Cell>{x.protocoin !== '0.00' ? '₱ ' + x.protocoin : '$ ' + x.amount}</Table.Cell>
 							</Table.Row>
 						)
 					:
@@ -341,7 +341,7 @@ export function Home(props) {
 		const printer_state = gcode_states?.[info?.gcode_state] || info?.gcode_state || 'Unknown';
 
 		if (printer_state === 'Running' && info?.current_layer === 0) {
-			return 'Initializing';  // because it has non-zero percentage which may be confusing
+			return 'Initializing';
 		} else if (printer_state === 'Running') {
 			let time_str = '';
 			const mins = parseInt(info?.remaining_time, 10);
@@ -471,7 +471,7 @@ export function Home(props) {
 
 							<img className='swordfish' src='/swordfish.png' onClick={() => refreshStats()} />
 
-							<div>
+							<div data-testid='home-stats-section'>
 								<Header size='medium'>Protospace Stats</Header>
 								<p>Shopping list: {stats?.shopping_list?.length ? <b>{renderShoppingListItems(stats.shopping_list)}</b> : 'Empty'} <a href='https://todo.protospace.ca/projects/4' target='_blank' rel='noopener noreferrer'>[list]</a></p>
 								<p>Maintenance list: {stats?.maintenance_list?.length ? <b>{renderMaintenanceListItems(stats.maintenance_list)}</b> : 'Empty'} <a href='https://todo.protospace.ca/projects/76' target='_blank' rel='noopener noreferrer'>[list]</a></p>

--- a/webclient/src/Home.js
+++ b/webclient/src/Home.js
@@ -171,7 +171,7 @@ function MemberInfo(props) {
 									<Link to={'/transactions/'+x.id}>{moment(x.date).format('ll')}</Link>
 								</Table.Cell>
 								<Table.Cell>{x.account_type}</Table.Cell>
-								<Table.Cell>{x.protocoin !== '0.00' ? '₱ ' + x.protocoin : '$ ' + x.amount}</Table.Cell>
+								<Table.Cell>{x.protocoin !== '0.00' ? '₱ ' + x.protocoin : '$ ' + x.amount}</Table.Cell>
 							</Table.Row>
 						)
 					:
@@ -341,7 +341,7 @@ export function Home(props) {
 		const printer_state = gcode_states?.[info?.gcode_state] || info?.gcode_state || 'Unknown';
 
 		if (printer_state === 'Running' && info?.current_layer === 0) {
-			return 'Initializing';
+			return 'Initializing';  // because it has non-zero percentage which may be confusing
 		} else if (printer_state === 'Running') {
 			let time_str = '';
 			const mins = parseInt(info?.remaining_time, 10);

--- a/webclient/src/Sign.js
+++ b/webclient/src/Sign.js
@@ -41,9 +41,10 @@ export function SignForm(props) {
 					onChange={handleChange}
 					value={sign}
 					error={error.sign}
+					data-testid='sign-and-vestaboard-input'
 				/>
 
-				<Form.Button loading={loading} error={error.non_field_errors}>
+				<Form.Button loading={loading} error={error.non_field_errors} data-testid='sign-and-vestaboard-submit'>
 					Submit
 				</Form.Button>
 			</Form.Group>
@@ -93,9 +94,10 @@ export function VestaboardForm(props) {
 					error={error.sign}
 					onFocus={() => setIsFocused(true)}
 					onBlur={() => setIsFocused(false)}
+					data-testid='vestaboard-only-input'
 				/>
 
-				<Form.Button loading={loading} error={error.non_field_errors}>
+				<Form.Button loading={loading} error={error.non_field_errors} data-testid='vestaboard-only-submit'>
 					Submit
 				</Form.Button>
 


### PR DESCRIPTION
## Problems

1. **Fragile DOM selectors** — `PublicMessagingPage.resource` used positional
   selectors (`nth=7`, `nth=8`, `text=Submit >> nth=0/1`) that break on any DOM change.
2. **Text-coupled page-ready guard** — `Wait Until Spaceport Page Ready` waited for
   `text=Protospace Stats`, tying test startup to a string that could change.
3. **`Page Should Contain Text` did a full body dump** — the keyword grabbed all body
   text and used `Should Contain`, which never waits; assertions could pass before
   content finished rendering.
4. **`HEADLESS` defaulted to `False`** — CI environments have no display server;
   tests would fail or require an Xvfb wrapper.
5. **`VALID_PASSWORD` committed in source** — credentials should come from environment
   variables.
6. **Debug screenshots overwrote each other** — `Test Teardown Capture Debug Artifact
   smoke` fired unconditionally on every test and always wrote the same filename,
   leaving only the last screenshot.
7. **No one-step setup script** — developers had to remember to run `pip install`
   *and* `rfbrowser init` separately.

## Solution

Add `data-testid` attributes to stable DOM landmarks in the React source, then update
all Robot selectors and infrastructure keywords to use them.

## Changes

### `webclient/src/Sign.js`
- `SignForm` — added `data-testid='sign-and-vestaboard-input'` / `data-testid='sign-and-vestaboard-submit'`
- `VestaboardForm` — added `data-testid='vestaboard-only-input'` / `data-testid='vestaboard-only-submit'`

### `webclient/src/Home.js`
- Wrapped the entire stats block in `<div data-testid="home-stats-section">` for a
  stable page-ready anchor

### `tests/robot/pages/PublicMessagingPage.resource`
- Replaced all positional `nth=` and `text=Submit >> nth=` selectors with
  `[data-testid="..."]` CSS attribute selectors

### `tests/robot/resources/Common.resource`
- `Wait Until Spaceport Page Ready` — now waits on `[data-testid="home-stats-section"]`
  instead of a text string
- `Page Should Contain Text` — replaced body dump + `Should Contain` with
  `Wait For Elements State ... visible` so assertions properly wait for the element

### `tests/robot/resources/Variables.resource`
- `HEADLESS` → `${True}` (CI-safe default; developers override with `-v HEADLESS:False`)
- `VALID_PASSWORD` → `%{TEST_PASSWORD=TestPass123!}` (env-var with fallback)

### `tests/robot/tests/smoke.robot`
- `Test Teardown` → `Run Keyword If Test Failed    Capture Debug Artifact    ${TEST NAME}`
  — screenshots now fire only on failure and use the test name for unique filenames

### `tests/robot/setup.sh` *(new)*
- Single script that chains `pip install -r requirements.txt` + `rfbrowser init`
